### PR TITLE
Fix rounding error in buildTypeTable.js

### DIFF
--- a/includes/buildTypeTable.js
+++ b/includes/buildTypeTable.js
@@ -521,7 +521,7 @@ function mergeTypes(prop1, prop2) {
 	for (i = 0; i < (Object.keys(merged.W)).length; i++) {
 		for (j = 0; j < (Object.keys(merged.R)).length; j++) {
 			if (Object.keys(merged.W)[i] === Object.keys(merged.R)[j]) {
-				var product = Math.round(((merged.W[Object.keys(merged.W)[i]] / 1 * merged.R[Object.keys(merged.R)[j]] / 1) + 0.00001) * 1000) / 1000;
+				var product = Math.trunc(((merged.W[Object.keys(merged.W)[i]] / 1 * merged.R[Object.keys(merged.R)[j]] / 1) + 0.00001) * 1000) / 1000;
 				/*console.log ("Merged "+Object.keys(merged.W)[i]+"("+merged.W[Object.keys(merged.W)[i]]/1+") and "+Object.keys(merged.R)[j]+"("+merged.R[Object.keys(merged.R)[j]]/1+") = "+product);*/
 
 				/*check the results of the merge*/


### PR DESCRIPTION
Fixing math error where weakness (1.6) X immunity (0.391) != 0.625 (incorrectly rounds to 0.626)